### PR TITLE
ImmutableMappable array now maps without throwing error

### DIFF
--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -109,8 +109,8 @@ public extension Map {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]'", file: file, function: function, line: line)
 		}
 		
-		return try jsonArray.map { JSONObject -> T in
-			return try Mapper<T>(context: context).mapOrFail(JSONObject: JSONObject)
+		return jsonArray.flatMap { JSONObject -> T? in
+			return try? Mapper<T>(context: context).mapOrFail(JSONObject: JSONObject)
 		}
 	}
 
@@ -121,11 +121,8 @@ public extension Map {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]'", file: file, function: function, line: line)
 		}
 		
-		return try jsonArray.map { json -> Transform.Object in
-			guard let object = transform.transformFromJSON(json) else {
-				throw MapError(key: "\(key)", currentValue: json, reason: "Cannot transform to '\(Transform.Object.self)' using \(transform)", file: file, function: function, line: line)
-			}
-			return object
+		return jsonArray.flatMap { json -> Transform.Object? in
+			return transform.transformFromJSON(json)
 		}
 	}
 

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -118,7 +118,7 @@ public final class Mapper<N: BaseMappable> {
 					exception = NSException(name: .init(rawValue: "ImmutableMappableError"), reason: error.localizedDescription, userInfo: nil)
 				}
 				exception.raise()
-				#else
+				#elseif DEBUG
 				NSLog("\(error)")
 				#endif
 			}

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -110,7 +110,7 @@ public final class Mapper<N: BaseMappable> {
 			do {
 				return try klass.init(map: map) as? N
 			} catch let error {
-				#if DEBUG
+				#if MAPPABLE_DEBUG
 				let exception: NSException
 				if let mapError = error as? MapError {
 					exception = NSException(name: .init(rawValue: "MapError"), reason: mapError.description, userInfo: nil)

--- a/Tests/ObjectMapperTests/MapContextTests.swift
+++ b/Tests/ObjectMapperTests/MapContextTests.swift
@@ -229,20 +229,6 @@ class MapContextTests: XCTestCase {
 		}
 	}
 	
-	func testArrayImmutableMappingWithoutContext() {
-		let JSON = ["persons": [["name": "Tristan"], ["name": "Anton"]]]
-		
-		do {
-			let _ = try Mapper<ImmutablePersonList>().map(JSON: JSON)
-		} catch ImmutablePersonMappingError.contextAbsense {
-			return
-		} catch {
-			XCTFail()
-		}
-		
-		XCTFail()
-	}
-	
 	// MARK: - Nested Types
 	// MARK: BaseMappable
 	struct Context: MapContext {


### PR DESCRIPTION
I believe it's common use case when some items in received json array are parsed with errors. 
In current scenario it leads to invalidation of the whole array and even the parent entity (owner of the array)
I offer to improve that logic and not forward errors from every item in array upward. Just invalidate it silently

In this PR I also included changes to compiler flags policy:
1. It isn't good idea to throw exception everytime some entity wasn't mapped successfuly. DEBUG flag is very popular among developers
2. NSLog influences performance -> better to remove it from release builds