### PR TITLE
Fixed CodableTransform for the case where the item is an array

### DIFF
--- a/Sources/CodableTransform.swift
+++ b/Sources/CodableTransform.swift
@@ -56,7 +56,7 @@ open class CodableTransform<T: Codable>: TransformType {
         do {
             let encoder = JSONEncoder()
             let data = try encoder.encode(item)
-            let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any]
+            let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
             return dictionary
         } catch {
             return nil


### PR DESCRIPTION
Currently, `CodableTransform` only works properly if the object to be serialized is a single item and not an array of items. This PR will enable also arrays to be serialized properly.