### PR TITLE
Fixed redundant 'public' and 'internal' modifier warnings

### DIFF
--- a/Sources/ISO8601DateTransform.swift
+++ b/Sources/ISO8601DateTransform.swift
@@ -29,7 +29,7 @@
 import Foundation
 
 public extension DateFormatter {
-	public convenience init(withFormat format : String, locale : String) {
+	convenience init(withFormat format : String, locale : String) {
 		self.init()
 		self.locale = Locale(identifier: locale)
 		dateFormat = format

--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -33,20 +33,20 @@ public protocol ImmutableMappable: BaseMappable {
 public extension ImmutableMappable {
 	
 	/// Implement this method to support object -> JSON transform.
-	public func mapping(map: Map) {}
+	func mapping(map: Map) {}
 	
 	/// Initializes object from a JSON String
-	public init(JSONString: String, context: MapContext? = nil) throws {
+	init(JSONString: String, context: MapContext? = nil) throws {
 		self = try Mapper(context: context).map(JSONString: JSONString)
 	}
 	
 	/// Initializes object from a JSON Dictionary
-	public init(JSON: [String: Any], context: MapContext? = nil) throws {
+	init(JSON: [String: Any], context: MapContext? = nil) throws {
 		self = try Mapper(context: context).map(JSON: JSON)
 	}
 	
 	/// Initializes object from a JSONObject
-	public init(JSONObject: Any, context: MapContext? = nil) throws {
+	init(JSONObject: Any, context: MapContext? = nil) throws {
 		self = try Mapper(context: context).map(JSONObject: JSONObject)
 	}
 	
@@ -62,7 +62,7 @@ public extension Map {
 	// MARK: Basic
 
 	/// Returns a value or throws an error.
-	public func value<T>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
+	func value<T>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let value = currentValue as? T else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '\(T.self)'", file: file, function: function, line: line)
@@ -71,7 +71,7 @@ public extension Map {
 	}
 
 	/// Returns a transformed value or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> Transform.Object {
+	func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> Transform.Object {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let value = transform.transformFromJSON(currentValue) else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot transform to '\(Transform.Object.self)' using \(transform)", file: file, function: function, line: line)
@@ -80,19 +80,19 @@ public extension Map {
 	}
 	
 	/// Returns a RawRepresentable type or throws an error.
-	public func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
+	func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
 		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
 	}
 	
 	/// Returns a `[RawRepresentable]` type or throws an error.
-	public func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
+	func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
 		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
 	}
 
 	// MARK: BaseMappable
 
 	/// Returns a `BaseMappable` object or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
+	func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let JSONObject = currentValue else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Found unexpected nil value", file: file, function: function, line: line)
@@ -103,7 +103,7 @@ public extension Map {
 	// MARK: [BaseMappable]
 
 	/// Returns a `[BaseMappable]` or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
+	func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonArray = currentValue as? [Any] else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]'", file: file, function: function, line: line)
@@ -115,7 +115,7 @@ public extension Map {
 	}
 
 	/// Returns a `[BaseMappable]` using transform or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [Transform.Object] {
+	func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [Transform.Object] {
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonArray = currentValue as? [Any] else {
 			throw MapError(key: key, currentValue: currentValue, reason: "Cannot cast to '[Any]'", file: file, function: function, line: line)
@@ -132,7 +132,7 @@ public extension Map {
 	// MARK: [String: BaseMappable]
 
 	/// Returns a `[String: BaseMappable]` or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: T] {
+	func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: T] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonDictionary = currentValue as? [String: Any] else {
@@ -146,7 +146,7 @@ public extension Map {
 	}
 
 	/// Returns a `[String: BaseMappable]` using transform or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: Transform.Object] {
+	func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [String: Transform.Object] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let jsonDictionary = currentValue as? [String: Any] else {
@@ -164,7 +164,7 @@ public extension Map {
 	
 	// MARK: [[BaseMappable]]
 	/// Returns a `[[BaseMappable]]` or throws an error.
-	public func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[T]] {
+	func value<T: BaseMappable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[T]] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let json2DArray = currentValue as? [[Any]] else {
@@ -178,7 +178,7 @@ public extension Map {
 	}
 	
 	/// Returns a `[[BaseMappable]]` using transform or throws an error.
-	public func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[Transform.Object]] {
+	func value<Transform: TransformType>(_ key: String, nested: Bool? = nil, delimiter: String = ".", using transform: Transform, file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [[Transform.Object]] {
 		
 		let currentValue = self.currentValue(for: key, nested: nested, delimiter: delimiter)
 		guard let json2DArray = currentValue as? [[Any]] else {
@@ -199,21 +199,21 @@ public extension Map {
 
 public extension Mapper where N: ImmutableMappable {
 	
-	public func map(JSON: [String: Any]) throws -> N {
+	func map(JSON: [String: Any]) throws -> N {
 		return try self.mapOrFail(JSON: JSON)
 	}
 	
-	public func map(JSONString: String) throws -> N {
+	func map(JSONString: String) throws -> N {
 		return try mapOrFail(JSONString: JSONString)
 	}
 	
-	public func map(JSONObject: Any) throws -> N {
+	func map(JSONObject: Any) throws -> N {
 		return try mapOrFail(JSONObject: JSONObject)
 	}
 	
 	// MARK: Array mapping functions
 	
-	public func mapArray(JSONArray: [[String: Any]]) throws -> [N] {
+	func mapArray(JSONArray: [[String: Any]]) throws -> [N] {
 		#if swift(>=4.1)
 		return try JSONArray.compactMap(mapOrFail)
 		#else
@@ -221,7 +221,7 @@ public extension Mapper where N: ImmutableMappable {
 		#endif
 	}
 	
-	public func mapArray(JSONString: String) throws -> [N] {
+	func mapArray(JSONString: String) throws -> [N] {
 		guard let JSONObject = Mapper.parseJSONString(JSONString: JSONString) else {
 			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot convert string into Any'")
 		}
@@ -229,7 +229,7 @@ public extension Mapper where N: ImmutableMappable {
 		return try mapArray(JSONObject: JSONObject)
 	}
 	
-	public func mapArray(JSONObject: Any) throws -> [N] {
+	func mapArray(JSONObject: Any) throws -> [N] {
 		guard let JSONArray = JSONObject as? [[String: Any]] else {
 			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[[String: Any]]'")
 		}
@@ -239,7 +239,7 @@ public extension Mapper where N: ImmutableMappable {
 
 	// MARK: Dictionary mapping functions
 
-	public func mapDictionary(JSONString: String) throws -> [String: N] {
+	func mapDictionary(JSONString: String) throws -> [String: N] {
 		guard let JSONObject = Mapper.parseJSONString(JSONString: JSONString) else {
 			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot convert string into Any'")
 		}
@@ -247,7 +247,7 @@ public extension Mapper where N: ImmutableMappable {
 		return try mapDictionary(JSONObject: JSONObject)
 	}
 
-	public func mapDictionary(JSONObject: Any?) throws -> [String: N] {
+	func mapDictionary(JSONObject: Any?) throws -> [String: N] {
 		guard let JSON = JSONObject as? [String: [String: Any]] else {
 			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[String: [String: Any]]''")
 		}
@@ -255,20 +255,20 @@ public extension Mapper where N: ImmutableMappable {
 		return try mapDictionary(JSON: JSON)
 	}
 
-	public func mapDictionary(JSON: [String: [String: Any]]) throws -> [String: N] {
+	func mapDictionary(JSON: [String: [String: Any]]) throws -> [String: N] {
 		return try JSON.filterMap(mapOrFail)
 	}
 
 	// MARK: Dictinoary of arrays mapping functions
 
-	public func mapDictionaryOfArrays(JSONObject: Any?) throws -> [String: [N]] {
+	func mapDictionaryOfArrays(JSONObject: Any?) throws -> [String: [N]] {
 		guard let JSON = JSONObject as? [String: [[String: Any]]] else {
 			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[String: [String: Any]]''")
 		}
 		return try mapDictionaryOfArrays(JSON: JSON)
 	}
 
-	public func mapDictionaryOfArrays(JSON: [String: [[String: Any]]]) throws -> [String: [N]] {
+	func mapDictionaryOfArrays(JSON: [String: [[String: Any]]]) throws -> [String: [N]] {
 		return try JSON.filterMap { array -> [N] in
 			try mapArray(JSONArray: array)
 		}
@@ -276,7 +276,7 @@ public extension Mapper where N: ImmutableMappable {
 
 	// MARK: 2 dimentional array mapping functions
 
-	public func mapArrayOfArrays(JSONObject: Any?) throws -> [[N]] {
+	func mapArrayOfArrays(JSONObject: Any?) throws -> [[N]] {
 		guard let JSONArray = JSONObject as? [[[String: Any]]] else {
 			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[[[String: Any]]]''")
 		}
@@ -287,7 +287,7 @@ public extension Mapper where N: ImmutableMappable {
 
 internal extension Mapper {
 
-	internal func mapOrFail(JSON: [String: Any]) throws -> N {
+	func mapOrFail(JSON: [String: Any]) throws -> N {
 		let map = Map(mappingType: .fromJSON, JSON: JSON, context: context, shouldIncludeNilValues: shouldIncludeNilValues)
 		
 		// Check if object is ImmutableMappable, if so use ImmutableMappable protocol for mapping
@@ -304,14 +304,14 @@ internal extension Mapper {
 		return value
 	}
 
-	internal func mapOrFail(JSONString: String) throws -> N {
+	func mapOrFail(JSONString: String) throws -> N {
 		guard let JSON = Mapper.parseJSONStringIntoDictionary(JSONString: JSONString) else {
 			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot parse into '[String: Any]'")
 		}
 		return try mapOrFail(JSON: JSON)
 	}
 
-	internal func mapOrFail(JSONObject: Any) throws -> N {
+	func mapOrFail(JSONObject: Any) throws -> N {
 		guard let JSON = JSONObject as? [String: Any] else {
 			throw MapError(key: nil, currentValue: JSONObject, reason: "Cannot cast to '[String: Any]'")
 		}

--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -49,7 +49,7 @@ public protocol StaticMappable: BaseMappable {
 public extension BaseMappable {
 	
 	/// Initializes object from a JSON String
-	public init?(JSONString: String, context: MapContext? = nil) {
+	init?(JSONString: String, context: MapContext? = nil) {
 		if let obj: Self = Mapper(context: context).map(JSONString: JSONString) {
 			self = obj
 		} else {
@@ -58,7 +58,7 @@ public extension BaseMappable {
 	}
 	
 	/// Initializes object from a JSON Dictionary
-	public init?(JSON: [String: Any], context: MapContext? = nil) {
+	init?(JSON: [String: Any], context: MapContext? = nil) {
 		if let obj: Self = Mapper(context: context).map(JSON: JSON) {
 			self = obj
 		} else {
@@ -67,12 +67,12 @@ public extension BaseMappable {
 	}
 	
 	/// Returns the JSON Dictionary for the object
-	public func toJSON() -> [String: Any] {
+	func toJSON() -> [String: Any] {
 		return Mapper().toJSON(self)
 	}
 	
 	/// Returns the JSON String for the object
-	public func toJSONString(prettyPrint: Bool = false) -> String? {
+	func toJSONString(prettyPrint: Bool = false) -> String? {
 		return Mapper().toJSONString(self, prettyPrint: prettyPrint)
 	}
 }
@@ -80,7 +80,7 @@ public extension BaseMappable {
 public extension Array where Element: BaseMappable {
 	
 	/// Initialize Array from a JSON String
-	public init?(JSONString: String, context: MapContext? = nil) {
+	init?(JSONString: String, context: MapContext? = nil) {
 		if let obj: [Element] = Mapper(context: context).mapArray(JSONString: JSONString) {
 			self = obj
 		} else {
@@ -89,18 +89,18 @@ public extension Array where Element: BaseMappable {
 	}
 	
 	/// Initialize Array from a JSON Array
-	public init(JSONArray: [[String: Any]], context: MapContext? = nil) {
+	init(JSONArray: [[String: Any]], context: MapContext? = nil) {
 		let obj: [Element] = Mapper(context: context).mapArray(JSONArray: JSONArray)
 		self = obj
 	}
 	
 	/// Returns the JSON Array
-	public func toJSON() -> [[String: Any]] {
+	func toJSON() -> [[String: Any]] {
 		return Mapper().toJSONArray(self)
 	}
 	
 	/// Returns the JSON String for the object
-	public func toJSONString(prettyPrint: Bool = false) -> String? {
+	func toJSONString(prettyPrint: Bool = false) -> String? {
 		return Mapper().toJSONString(self, prettyPrint: prettyPrint)
 	}
 }
@@ -108,7 +108,7 @@ public extension Array where Element: BaseMappable {
 public extension Set where Element: BaseMappable {
 	
 	/// Initializes a set from a JSON String
-	public init?(JSONString: String, context: MapContext? = nil) {
+	init?(JSONString: String, context: MapContext? = nil) {
 		if let obj: Set<Element> = Mapper(context: context).mapSet(JSONString: JSONString) {
 			self = obj
 		} else {
@@ -117,7 +117,7 @@ public extension Set where Element: BaseMappable {
 	}
 	
 	/// Initializes a set from JSON
-	public init?(JSONArray: [[String: Any]], context: MapContext? = nil) {
+	init?(JSONArray: [[String: Any]], context: MapContext? = nil) {
 		guard let obj = Mapper(context: context).mapSet(JSONArray: JSONArray) as Set<Element>? else {
             return nil
         }
@@ -125,12 +125,12 @@ public extension Set where Element: BaseMappable {
 	}
 	
 	/// Returns the JSON Set
-	public func toJSON() -> [[String: Any]] {
+	func toJSON() -> [[String: Any]] {
 		return Mapper().toJSONSet(self)
 	}
 	
 	/// Returns the JSON String for the object
-	public func toJSONString(prettyPrint: Bool = false) -> String? {
+	func toJSONString(prettyPrint: Bool = false) -> String? {
 		return Mapper().toJSONString(self, prettyPrint: prettyPrint)
 	}
 }


### PR DESCRIPTION
This merge request fixes the redundant 'public' and 'internal' modifier warnings that appear in Xcode 10.2