### PR TITLE
Fix: Could not map to optional RawRepresentable enum for ImmutableMappable

### DIFF
--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -84,8 +84,18 @@ public extension Map {
 		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
 	}
 	
+	/// Returns a RawRepresentable type or throws an error.
+	func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> T? {
+		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
+	}
+
 	/// Returns a `[RawRepresentable]` type or throws an error.
 	func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T] {
+		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
+	}
+
+	/// Returns a `[RawRepresentable]` type or throws an error.
+	func value<T: RawRepresentable>(_ key: String, nested: Bool? = nil, delimiter: String = ".", file: StaticString = #file, function: StaticString = #function, line: UInt = #line) throws -> [T]? {
 		return try self.value(key, nested: nested, delimiter: delimiter, using: EnumTransform(), file: file, function: function, line: line)
 	}
 

--- a/Tests/ObjectMapperTests/ImmutableTests.swift
+++ b/Tests/ObjectMapperTests/ImmutableTests.swift
@@ -331,6 +331,34 @@ class ImmutableObjectTests: XCTestCase {
 		XCTAssertEqual(object?.immutable?.value, "Hello")
 	}
 	
+	func testAsPropertyOfOptionalImmutableMappable() {
+		struct ImmutableObject: ImmutableMappable {
+			let value: String?
+			init(map: Map) throws {
+				self.value = try map.value("value")
+			}
+		}
+
+		struct Object: ImmutableMappable {
+			let immutable: ImmutableObject?
+			init(map: Map) throws {
+				self.immutable = try map.value("immutable")
+			}
+		}
+
+		let json: [String: Any] = [
+			"immutable": [
+				"value": "Hello"
+			]
+		]
+		do {
+			let object = try Mapper<Object>().map(JSON: json)
+			XCTAssertEqual(object.immutable?.value, "Hello")
+		} catch {
+			XCTFail()
+		}
+	}
+
 }
 
 struct Struct {

--- a/Tests/ObjectMapperTests/ImmutableTests.swift
+++ b/Tests/ObjectMapperTests/ImmutableTests.swift
@@ -339,21 +339,28 @@ class ImmutableObjectTests: XCTestCase {
 			}
 		}
 
+		enum RawRepresentableEnum: String {
+			case world
+		}
 		struct Object: ImmutableMappable {
 			let immutable: ImmutableObject?
+			let enumValue: RawRepresentableEnum?
 			init(map: Map) throws {
 				self.immutable = try map.value("immutable")
+				self.enumValue = try map.value("enum")
 			}
 		}
 
 		let json: [String: Any] = [
 			"immutable": [
 				"value": "Hello"
-			]
+			],
+			"enum": "world"
 		]
 		do {
 			let object = try Mapper<Object>().map(JSON: json)
 			XCTAssertEqual(object.immutable?.value, "Hello")
+			XCTAssertEqual(object.enumValue, .world)
 		} catch {
 			XCTFail()
 		}


### PR DESCRIPTION
Related #1043, #1057.

This PR fixed #1057(it fixed for `BaseMappable`) missing part of `RawRepresentable`.

Test code is based on my #1058, it will be dismissed if this merge.