### PR TITLE
move Mapper static func to MapperParse

### DIFF
--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -147,6 +147,10 @@
 		C135CABA1D7631DB00BA9338 /* DataTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135CAB31D762F6900BA9338 /* DataTransform.swift */; };
 		C135CABB1D7631DB00BA9338 /* DataTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135CAB31D762F6900BA9338 /* DataTransform.swift */; };
 		C135CABC1D7631DC00BA9338 /* DataTransform.swift in Sources */ = {isa = PBXBuildFile; fileRef = C135CAB31D762F6900BA9338 /* DataTransform.swift */; };
+		C7A1C2B322B3A48100858848 /* MapperParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1C2B222B3A48100858848 /* MapperParse.swift */; };
+		C7A1C2B422B3A48100858848 /* MapperParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1C2B222B3A48100858848 /* MapperParse.swift */; };
+		C7A1C2B522B3A48100858848 /* MapperParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1C2B222B3A48100858848 /* MapperParse.swift */; };
+		C7A1C2B622B3A48100858848 /* MapperParse.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A1C2B222B3A48100858848 /* MapperParse.swift */; };
 		CD16030A1AC023D6000CD69A /* ObjectMapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */; };
 		CD1603181AC02437000CD69A /* ObjectMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 6AAC8F7B19F03C2900E7A677 /* ObjectMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CD1603191AC02451000CD69A /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAC8FC419F048FE00E7A677 /* Mapper.swift */; };
@@ -300,6 +304,7 @@
 		BC1E7F361ABC44C000F9B1CF /* EnumTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnumTransform.swift; sourceTree = "<group>"; };
 		C135CAB31D762F6900BA9338 /* DataTransform.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataTransform.swift; sourceTree = "<group>"; };
 		C135CAB61D76303E00BA9338 /* DataTransformTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DataTransformTests.swift; path = ObjectMapperTests/DataTransformTests.swift; sourceTree = "<group>"; };
+		C7A1C2B222B3A48100858848 /* MapperParse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapperParse.swift; sourceTree = "<group>"; };
 		CD1602FF1AC023D5000CD69A /* ObjectMapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectMapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD1603091AC023D6000CD69A /* ObjectMapper-macOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ObjectMapper-macOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD44374C1AAE9C1100A271BA /* NestedKeysTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = NestedKeysTests.swift; path = ObjectMapperTests/NestedKeysTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
@@ -478,6 +483,7 @@
 				3BAD2C0B1BDDB10D00E6B203 /* Mappable.swift */,
 				030114A81D95187600FBFD4F /* ImmutableMappable.swift */,
 				6AAC8FC419F048FE00E7A677 /* Mapper.swift */,
+				C7A1C2B222B3A48100858848 /* MapperParse.swift */,
 				6AF148961D99A912002BEA2C /* Operators */,
 				6AAC8FC319F048FE00E7A677 /* FromJSON.swift */,
 				6AAC8FC719F048FE00E7A677 /* ToJSON.swift */,
@@ -839,6 +845,7 @@
 				6AC692361BE3FD3A004C119A /* Operators.swift in Sources */,
 				84D4F8551CC3B643008B0FB6 /* NSDecimalNumberTransform.swift in Sources */,
 				6AC692371BE3FD3A004C119A /* FromJSON.swift in Sources */,
+				C7A1C2B622B3A48100858848 /* MapperParse.swift in Sources */,
 				6AF148951D99A7CA002BEA2C /* EnumOperators.swift in Sources */,
 				997B4A4A1D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,
 				6AC692381BE3FD3A004C119A /* ToJSON.swift in Sources */,
@@ -898,6 +905,7 @@
 				6ACB15D41BC7F1D0006C029C /* Map.swift in Sources */,
 				84D4F8541CC3B643008B0FB6 /* NSDecimalNumberTransform.swift in Sources */,
 				6A2AD0471B2C786C0097E150 /* FromJSON.swift in Sources */,
+				C7A1C2B522B3A48100858848 /* MapperParse.swift in Sources */,
 				6AF148941D99A7CA002BEA2C /* EnumOperators.swift in Sources */,
 				997B4A491D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,
 				6A2AD0481B2C786C0097E150 /* ToJSON.swift in Sources */,
@@ -929,6 +937,7 @@
 				6ACB15D21BC7F1D0006C029C /* Map.swift in Sources */,
 				84D4F8521CC3B643008B0FB6 /* NSDecimalNumberTransform.swift in Sources */,
 				6AAC8FD319F048FE00E7A677 /* DateTransform.swift in Sources */,
+				C7A1C2B322B3A48100858848 /* MapperParse.swift in Sources */,
 				6AF148921D99A7CA002BEA2C /* EnumOperators.swift in Sources */,
 				997B4A471D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,
 				BC1E7F371ABC44C000F9B1CF /* EnumTransform.swift in Sources */,
@@ -989,6 +998,7 @@
 				CD1603201AC02461000CD69A /* CustomDateFormatTransform.swift in Sources */,
 				CD16031E1AC02461000CD69A /* DateFormatterTransform.swift in Sources */,
 				84D4F8531CC3B643008B0FB6 /* NSDecimalNumberTransform.swift in Sources */,
+				C7A1C2B422B3A48100858848 /* MapperParse.swift in Sources */,
 				6AF148931D99A7CA002BEA2C /* EnumOperators.swift in Sources */,
 				6ACB15D31BC7F1D0006C029C /* Map.swift in Sources */,
 				997B4A481D3FA20D005E3F31 /* DictionaryTransform.swift in Sources */,

--- a/Sources/ImmutableMappable.swift
+++ b/Sources/ImmutableMappable.swift
@@ -267,7 +267,7 @@ public extension Mapper where N: ImmutableMappable {
 	}
 	
 	func mapArray(JSONString: String) throws -> [N] {
-		guard let JSONObject = Mapper.parseJSONString(JSONString: JSONString) else {
+		guard let JSONObject = MapperParse.toJSONObject(JSONString: JSONString) else {
 			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot convert string into Any'")
 		}
 		
@@ -285,7 +285,7 @@ public extension Mapper where N: ImmutableMappable {
 	// MARK: Dictionary mapping functions
 
 	func mapDictionary(JSONString: String) throws -> [String: N] {
-		guard let JSONObject = Mapper.parseJSONString(JSONString: JSONString) else {
+		guard let JSONObject = MapperParse.toJSONObject(JSONString: JSONString) else {
 			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot convert string into Any'")
 		}
 
@@ -350,7 +350,7 @@ internal extension Mapper {
 	}
 
 	func mapOrFail(JSONString: String) throws -> N {
-		guard let JSON = Mapper.parseJSONStringIntoDictionary(JSONString: JSONString) else {
+		guard let JSON = MapperParse.toJSONDictionary(JSONString: JSONString) else {
 			throw MapError(key: nil, currentValue: JSONString, reason: "Cannot parse into '[String: Any]'")
 		}
 		return try mapOrFail(JSON: JSON)

--- a/Sources/Mapper.swift
+++ b/Sources/Mapper.swift
@@ -57,7 +57,7 @@ public final class Mapper<N: BaseMappable> {
 	
 	/// Map a JSON string onto an existing object
 	public func map(JSONString: String, toObject object: N) -> N {
-		if let JSON = Mapper.parseJSONStringIntoDictionary(JSONString: JSONString) {
+		if let JSON = MapperParse.toJSONDictionary(JSONString: JSONString) {
 			return map(JSON: JSON, toObject: object)
 		}
 		return object
@@ -76,7 +76,7 @@ public final class Mapper<N: BaseMappable> {
 	
 	/// Map a JSON string to an object that conforms to Mappable
 	public func map(JSONString: String) -> N? {
-		if let JSON = Mapper.parseJSONStringIntoDictionary(JSONString: JSONString) {
+		if let JSON = MapperParse.toJSONDictionary(JSONString: JSONString) {
 			return map(JSON: JSON)
 		}
 		
@@ -135,7 +135,7 @@ public final class Mapper<N: BaseMappable> {
 	
 	/// Maps a JSON array to an object that conforms to Mappable
 	public func mapArray(JSONString: String) -> [N]? {
-		let parsedJSON: Any? = Mapper.parseJSONString(JSONString: JSONString)
+		let parsedJSON: Any? = MapperParse.toJSONObject(JSONString: JSONString)
 
 		if let objectArray = mapArray(JSONObject: parsedJSON) {
 			return objectArray
@@ -172,7 +172,7 @@ public final class Mapper<N: BaseMappable> {
 	
 	/// Maps a JSON object to a dictionary of Mappable objects if it is a JSON dictionary of dictionaries, or returns nil.
 	public func mapDictionary(JSONString: String) -> [String: N]? {
-		let parsedJSON: Any? = Mapper.parseJSONString(JSONString: JSONString)
+		let parsedJSON: Any? = MapperParse.toJSONObject(JSONString: JSONString)
 		return mapDictionary(JSONObject: parsedJSON)
 	}
 	
@@ -260,12 +260,14 @@ public final class Mapper<N: BaseMappable> {
 	// MARK: Utility functions for converting strings to JSON objects
 	
 	/// Convert a JSON String into a Dictionary<String, Any> using NSJSONSerialization
+	@available(*, deprecated, message:"Use MapperParse")
 	public static func parseJSONStringIntoDictionary(JSONString: String) -> [String: Any]? {
 		let parsedJSON: Any? = Mapper.parseJSONString(JSONString: JSONString)
 		return parsedJSON as? [String: Any]
 	}
 
 	/// Convert a JSON String into an Object using NSJSONSerialization
+	@available(*, deprecated, message:"Use MapperParse")
 	public static func parseJSONString(JSONString: String) -> Any? {
 		let data = JSONString.data(using: String.Encoding.utf8, allowLossyConversion: true)
 		if let data = data {
@@ -361,17 +363,18 @@ extension Mapper {
 	public func toJSONString(_ object: N, prettyPrint: Bool = false) -> String? {
 		let JSONDict = toJSON(object)
 		
-        return Mapper.toJSONString(JSONDict as Any, prettyPrint: prettyPrint)
+        return MapperParse.toJSONString(JSONDict as Any, prettyPrint: prettyPrint)
 	}
 
     /// Maps an array of Objects to a JSON string with option of pretty formatting	
     public func toJSONString(_ array: [N], prettyPrint: Bool = false) -> String? {
         let JSONDict = toJSONArray(array)
         
-        return Mapper.toJSONString(JSONDict as Any, prettyPrint: prettyPrint)
+        return MapperParse.toJSONString(JSONDict as Any, prettyPrint: prettyPrint)
     }
 	
 	/// Converts an Object to a JSON string with option of pretty formatting
+	@available(*, deprecated, message:"Use MapperParse")
 	public static func toJSONString(_ JSONObject: Any, prettyPrint: Bool) -> String? {
 		let options: JSONSerialization.WritingOptions = prettyPrint ? .prettyPrinted : []
 		if let JSON = Mapper.toJSONData(JSONObject, options: options) {
@@ -382,6 +385,7 @@ extension Mapper {
 	}
 	
 	/// Converts an Object to JSON data with options
+	@available(*, deprecated, message:"Use MapperParse")
 	public static func toJSONData(_ JSONObject: Any, options: JSONSerialization.WritingOptions) -> Data? {
 		if JSONSerialization.isValidJSONObject(JSONObject) {
 			let JSONData: Data?
@@ -403,7 +407,7 @@ extension Mapper where N: Hashable {
 	
 	/// Maps a JSON array to an object that conforms to Mappable
 	public func mapSet(JSONString: String) -> Set<N>? {
-		let parsedJSON: Any? = Mapper.parseJSONString(JSONString: JSONString)
+		let parsedJSON: Any? = MapperParse.toJSONObject(JSONString: JSONString)
 		
 		if let objectArray = mapArray(JSONObject: parsedJSON) {
 			return Set(objectArray)
@@ -449,7 +453,7 @@ extension Mapper where N: Hashable {
 	public func toJSONString(_ set: Set<N>, prettyPrint: Bool = false) -> String? {
 		let JSONDict = toJSONSet(set)
 		
-		return Mapper.toJSONString(JSONDict as Any, prettyPrint: prettyPrint)
+		return MapperParse.toJSONString(JSONDict as Any, prettyPrint: prettyPrint)
 	}
 }
 

--- a/Sources/MapperParse.swift
+++ b/Sources/MapperParse.swift
@@ -1,0 +1,64 @@
+//
+//  MapperParse.swift
+//  ObjectMapper-iOS
+//
+//  Created by yixiaojichunqiu on 2019/6/13.
+//  Copyright © 2019 hearst. All rights reserved.
+//
+
+import Foundation
+
+public final class MapperParse
+{
+	/// Converts an Object to a JSON string with option of pretty formatting
+	public static func toJSONString(_ JSONObject: Any, prettyPrint: Bool) -> String? {
+		let options: JSONSerialization.WritingOptions = prettyPrint ? .prettyPrinted : []
+		if let JSON = MapperParse.toJSONData(JSONObject, options: options) {
+			return String(data: JSON, encoding: String.Encoding.utf8)
+		}
+		
+		return nil
+	}
+	
+	/// Converts an Object to JSON data with options
+	public static func toJSONData(_ JSONObject: Any, options: JSONSerialization.WritingOptions) -> Data? {
+		if JSONSerialization.isValidJSONObject(JSONObject) {
+			let JSONData: Data?
+			do {
+				JSONData = try JSONSerialization.data(withJSONObject: JSONObject, options: options)
+			} catch let error {
+				print(error)
+				JSONData = nil
+			}
+			
+			return JSONData
+		}
+		
+		return nil
+	}
+	
+	// MARK: Utility functions for converting strings to JSON objects
+	
+	/// Convert a JSON String into a Dictionary<String, Any> using NSJSONSerialization
+	public static func toJSONDictionary(JSONString: String) -> [String: Any]? {
+		let parsedJSON: Any? = MapperParse.toJSONObject(JSONString: JSONString)
+		return parsedJSON as? [String: Any]
+	}
+	
+	/// Convert a JSON String into an Object using NSJSONSerialization
+	public static func toJSONObject(JSONString: String) -> Any? {
+		let data = JSONString.data(using: String.Encoding.utf8, allowLossyConversion: true)
+		if let data = data {
+			let parsedJSON: Any?
+			do {
+				parsedJSON = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.allowFragments)
+			} catch let error {
+				print(error)
+				parsedJSON = nil
+			}
+			return parsedJSON
+		}
+		
+		return nil
+	}
+}


### PR DESCRIPTION
later code,when i use `public static func toJSONString(_ JSONObject: Any, prettyPrint: Bool) -> String?` very inconvenient. Mapper use generic and these func will happen Generic parameter 'N' could not be inferred.I think these static func not in Mapper will be better.
