### PR TITLE
ImmutableMappable init fix

### DIFF
--- a/Sources/Mappable.swift
+++ b/Sources/Mappable.swift
@@ -46,7 +46,7 @@ public protocol StaticMappable: BaseMappable {
 	static func objectForMapping(map: Map) -> BaseMappable?
 }
 
-public extension BaseMappable {
+public extension Mappable {
 	
 	/// Initializes object from a JSON String
 	init?(JSONString: String, context: MapContext? = nil) {
@@ -65,12 +65,15 @@ public extension BaseMappable {
 			return nil
 		}
 	}
-	
+}
+
+public extension BaseMappable {
+
 	/// Returns the JSON Dictionary for the object
 	func toJSON() -> [String: Any] {
 		return Mapper().toJSON(self)
 	}
-	
+
 	/// Returns the JSON String for the object
 	func toJSONString(prettyPrint: Bool = false) -> String? {
 		return Mapper().toJSONString(self, prettyPrint: prettyPrint)


### PR DESCRIPTION
I've started research to fix warning mentioned here:
https://github.com/tristanhimmelman/ObjectMapper/issues/1043#issuecomment-479406127

If you try to init ImmutableMappable with JSONString - swift shows warning that this method has no calls to throwing functions.

I found that:
- `ImmutableMappable` inherits from `BaseMappable`
- `ImmutableMappable` has an extension with init methods which throws (like `init(JSONString: String, context: MapContext? = nil) throws`)
- `BaseMappable` has an extension with optional init methods (like `init?(JSONString: String, context: MapContext? = nil)`)

It causes crashes in some cases.

For example:
`let response = try? MyModel(JSONString: jsonString)` will crash if `MyModel` is ImmutableMappable and throws in init method.

I'm not sure but it can be caused by selecting optional init from `BaseMappable` which not marked with `throws`.