### PR TITLE
Update readme, added JSON to model struct generator link

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ Note: Generating a JSON string of a Realm Object using ObjectMappers' `toJSON` f
 
 - [Json4Swift - Supports generating `ImmutableMappable` structs online (no plugins needed)](http://www.json4swift.com)
 
+- [JSON to Model - Template based MacOS app which generates structs with customisation.](https://github.com/chanonly123/Json-Model-Generator)  [⬇️Download App](https://github.com/chanonly123/Json-Model-Generator/raw/master/JsonToModel.zip)
+
 If you have a project that utilizes, extends or provides tooling for ObjectMapper, please submit a PR with a link to your project in this section of the README.
 
 # To Do


### PR DESCRIPTION
## Why 
I created a JSON to struct generator MacOS app using templates. Which supports generating struct models in many languages and platforms including ObjectMapper, so please put the link in readme.
[chanonly123/Json-Model-Generator](https://github.com/chanonly123/Json-Model-Generator)

## What 
Added link to my JSON to struct Model generator app in readme