### PR TITLE
bump swift tools version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 
 import PackageDescription
 


### PR DESCRIPTION
## Why <!-- Describe why you are making the change -->
I bumped the version because `.v13` requires swift-tools-version 5.1.
https://developer.apple.com/documentation/packagedescription/supportedplatform/iosversion/v13