### PR TITLE
Mac OS version fix in Podspec

### DIFF
--- a/ObjectMapper.podspec
+++ b/ObjectMapper.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   s.watchos.deployment_target = '2.0'
   s.ios.deployment_target = '13.0'
-  s.osx.deployment_target = '10.9'
+  s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
 
   s.swift_version = '5.0'


### PR DESCRIPTION
## Why <!-- Describe why you are making the change -->

I'm getting errors when trying to publish https://github.com/APUtils/ObjectMapperAdditions which depends on this pod
```
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild: Returned an unsuccessful exit code.
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/CodableTransform.swift:40:16: error: 'Data' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/CodableTransform.swift:52:27: error: 'JSONDecoder' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/CodableTransform.swift:65:27: error: 'JSONEncoder' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/CustomDateFormatTransform.swift:35:22: error: 'Locale' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DataTransform.swift:32:28: error: 'Data' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DataTransform.swift:37:48: error: 'Data' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DataTransform.swift:44:37: error: 'Data' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DataTransform.swift:41:10: error: 'Data' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DataTransform.swift:41:10: error: 'init(base64Encoded:options:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DataTransform.swift:48:15: error: 'base64EncodedString(options:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DateFormatterTransform.swift:32:28: error: 'Date' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DateFormatterTransform.swift:41:48: error: 'Date' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DateFormatterTransform.swift:48:37: error: 'Date' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DateTransform.swift:32:28: error: 'Date' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DateTransform.swift:54:48: error: 'Date' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DateTransform.swift:69:37: error: 'Date' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/DateTransform.swift:65:11: error: 'Date' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/HexColorTransform.swift:93:16: error: 'init(format:_:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/HexColorTransform.swift:96:17: error: 'init(format:_:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/ImmutableMappable.swift:58:32: error: 'contains' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/ISO8601DateTransform.swift:34:17: error: 'Locale' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Map.swift:99:31: error: 'contains' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Map.swift:107:60: error: 'components(separatedBy:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/MapError.swift:53:45: error: 'components(separatedBy:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/MapError.swift:53:86: error: 'components(separatedBy:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:387:97: error: 'Data' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:272:25: error: 'data(using:allowLossyConversion:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:272:44: error: 'Encoding' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:297:26: error: 'init(contentsOfFile:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:314:26: error: 'init(contentsOfFile:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:380:11: error: 'init(data:encoding:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:380:47: error: 'Encoding' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/Mapper.swift:389:18: error: 'Data' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/NSDecimalNumberTransform.swift:43:20: error: 'init(floatLiteral:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/ToJSON.swift:37:38: error: 'components(separatedBy:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:32:28: error: 'URL' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:35:35: error: 'CharacterSet' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:43:72: error: 'CharacterSet' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:48:48: error: 'URL' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:61:37: error: 'URL' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:52:11: error: 'URL' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:55:42: error: 'addingPercentEncoding(withAllowedCharacters:)' is only available in macOS 10.10 or newer
    - ERROR | [ObjectMapperAdditions/Core,ObjectMapperAdditions/Realm] xcodebuild:  ObjectMapper/Sources/URLTransform.swift:58:10: error: 'URL' is only available in macOS 10.10 or newer
```

## What <!-- Describe what changed -->

Podspec is fixed