### PR TITLE
feature: change swift-tools-versions to 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 
 import PackageDescription
 


### PR DESCRIPTION
## Why <!-- Describe why you are making the change -->
// swift-tools-version:5.0 doesn't work in Xcode 15,  Sonoma 14.2.1


## What <!-- Describe what changed -->
change to // swift-tools-version:5.3 now works