### PR TITLE
Revert the original config to support old ios version

### DIFF
--- a/ObjectMapper.podspec
+++ b/ObjectMapper.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ObjectMapper'
-  s.version = '4.4.0'
+  s.version = '4.4.2'
   s.license = 'MIT'
   # Ensure developers won't hit CocoaPods/CocoaPods#11402 with the resource
   # bundle for the privacy manifest.
@@ -12,10 +12,10 @@ Pod::Spec.new do |s|
   s.resource_bundle = {
     "Privacy" => "Sources/Resources/PrivacyInfo.xcprivacy"
   }
-  s.watchos.deployment_target = '10.0'
-  s.ios.deployment_target = '17.0'
+  s.watchos.deployment_target = '2.0'
+  s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '12.0'
-  s.tvos.deployment_target = '17.0'
+  s.tvos.deployment_target = '9.0'
 
   s.swift_version = '5.0'
 

--- a/ObjectMapper.xcodeproj/project.pbxproj
+++ b/ObjectMapper.xcodeproj/project.pbxproj
@@ -1114,7 +1114,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 17.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
@@ -1143,7 +1143,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 17.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
@@ -1161,7 +1161,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 4.2;
-				TVOS_DEPLOYMENT_TARGET = 17.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
@@ -1179,7 +1179,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 4.2;
-				TVOS_DEPLOYMENT_TARGET = 17.0;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -1207,7 +1207,7 @@
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -1235,7 +1235,7 @@
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 4;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
-				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
@@ -1363,7 +1363,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tristanhimmelman.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
@@ -1386,7 +1386,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.tristanhimmelman.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(PROJECT_NAME)";
@@ -1407,7 +1407,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heart.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1421,7 +1421,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.heart.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@ import PackageDescription
 
 let package = Package(name: "ObjectMapper",
                       platforms: [.macOS(.v12),
-                                  .iOS(.v17),
-                                  .tvOS(.v17),
-                                  .watchOS(.v10)],
+                                  .iOS(.v13),
+                                  .tvOS(.v9),
+                                  .watchOS(.v2)],
                       products: [.library(name: "ObjectMapper",
                                           targets: ["ObjectMapper"])],
                       targets: [.target(name: "ObjectMapper",


### PR DESCRIPTION
## Why <!-- Describe why you are making the change -->
https://github.com/tristanhimmelman/ObjectMapper/pull/1142#discussion_r1571907250

> I assume "must be built with [Xcode 15](https://apps.apple.com/us/app/xcode/id497799835?mt=12) for [iOS 17](https://developer.apple.com/ios/)..." does not mean we should set the deployment target to iOS 17 as it will break most existing clients of the library who still might support earlier iOS versions.
> 
> If you check https://developer.apple.com/ios/submit/ it just says "must be built with a minimum of Xcode 15 and the iOS 17 SDK." There is no limitation to the deployment target it just has to be built with Xcode 15 and the latest SDK which makes sense.
> 
> I believe we will have to revert most of the introduced limitations in this pull request.

## What <!-- Describe what changed -->
- Reverted min target version to support old ios version

## Test case
<img width="1822" alt="Screenshot 2024-04-23 at 10 08 02" src="https://github.com/tristanhimmelman/ObjectMapper/assets/56902167/021dd4c8-567f-48ad-9ae1-f35935553bfb">
<img width="1822" alt="Screenshot 2024-04-23 at 10 15 05" src="https://github.com/tristanhimmelman/ObjectMapper/assets/56902167/4c140add-95be-44ef-8be7-e210eddca90d">
